### PR TITLE
fix: Remove wrapping quotes to ensure value is a boolean and not a string

### DIFF
--- a/state_machine.json
+++ b/state_machine.json
@@ -6,7 +6,7 @@
       "Type": "Pass",
       "Comment": "Define default values used when input values are not provided",
       "Parameters": {
-        "EnableFastSnapshotRestore": "${default_values.enable_fast_snapshot_restore}",
+        "EnableFastSnapshotRestore": ${default_values.enable_fast_snapshot_restore},
         "SnapshotName": "${default_values.snapshot_name}",
         "SnapshotDescription": "${default_values.snapshot_description}"
       },


### PR DESCRIPTION
## Description
- Remove wrapping quotes to ensure value is a boolean and not a string

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
